### PR TITLE
Added token changes to ESPNPlayer lib

### DIFF
--- a/resources/lib/espnplayer.py
+++ b/resources/lib/espnplayer.py
@@ -167,7 +167,7 @@ class ESPNPlayer(object):
             'auth_timestamp': espntoken['timestamp'],
             'auth_token': espntoken['token'],
             'auth_usertrackname': espntoken['userTrackName'],
-            'simulcastAiringId': airing_id if chennel!='espn3' else 0
+            'simulcastAiringId': airing_id if channel!='espn3' else 0
         }
         req = self.make_request(url=url, method='post', payload=payload)
         stream_data = req.content

--- a/resources/lib/espnplayer.py
+++ b/resources/lib/espnplayer.py
@@ -124,11 +124,26 @@ class ESPNPlayer(object):
         data = self.make_request(url, method='get', params=params)
         return data
 
-    def get_pkan(self, airing_id):
+    def get_espntoken(self, airing_id):
+        """Return a token needed to request a pkan/stream"""
+        url = 'https://www.espnplayer.com/secure/espntoken'
+        payload = {
+            'airingId': airing_id,
+            'format': 'json',
+        }
+        sc_data = self.make_request(url=url, method='post', payload=payload)
+        return json.loads(sc_data)['data']
+
+    def get_pkan(self, token):
         """Return a 'pkan' token needed to request a stream URL."""
         url = 'http://neulion.go.com/espngeo/dgetpkan'
         payload = {
-            'airingId': airing_id
+            'airingId': airing_id,
+            'auth_airingid': token['airingId'],
+            'auth_timestamp': token['timestamp'],
+            'auth_token': token['token'],
+            'auth_usertrackname': token['userTrackName'],
+            'isFlex': 'true'
         }
         pkan = self.make_request(url=url, method='get', payload=payload)
         return pkan
@@ -137,16 +152,22 @@ class ESPNPlayer(object):
         """Return the URL for a stream. _mediaAuth cookie is needed for decryption."""
         stream_url = {}
         auth_cookie = None
+        espntoken = self.get_espntoken(airing_id)
         url = 'http://neulion.go.com/espngeo/startSession'
         payload = {
             'channel': channel,
-            'simulcastAiringId': airing_id,
             'playbackScenario': 'HTTP_CLOUD_WIRED',
             'playerId': 'neulion',
-            'pkan': self.get_pkan(airing_id),
+            'pkan': self.get_pkan(espntoken),
             'pkanType': 'TOKEN',
             'tokenType': 'GATEKEEPER',
-            'ttl': '480'
+            'ttl': '480',
+            'airingId': airing_id,
+            'auth_airingid': espntoken['airingId'],
+            'auth_timestamp': espntoken['timestamp'],
+            'auth_token': espntoken['token'],
+            'auth_usertrackname': espntoken['userTrackName'],
+            'simulcastAiringId': airing_id if channel!='espn3' else 0
         }
         req = self.make_request(url=url, method='post', payload=payload)
         stream_data = req.content

--- a/resources/lib/espnplayer.py
+++ b/resources/lib/espnplayer.py
@@ -131,8 +131,8 @@ class ESPNPlayer(object):
             'airingId': airing_id,
             'format': 'json',
         }
-        sc_data = self.make_request(url=url, method='post', payload=payload)
-        return json.loads(sc_data)['data']
+        data = self.make_request(url=url, method='post', payload=payload)
+        return data['data']
 
     def get_pkan(self, airing_id, token):
         """Return a 'pkan' token needed to request a stream URL."""

--- a/resources/lib/espnplayer.py
+++ b/resources/lib/espnplayer.py
@@ -125,7 +125,7 @@ class ESPNPlayer(object):
         return data
 
     def get_espntoken(self, airing_id):
-        """Return a token needed to request a pkan/stream"""
+        """Return a token needed to request a pkan"""
         url = 'https://www.espnplayer.com/secure/espntoken'
         payload = {
             'airingId': airing_id,
@@ -134,7 +134,7 @@ class ESPNPlayer(object):
         sc_data = self.make_request(url=url, method='post', payload=payload)
         return json.loads(sc_data)['data']
 
-    def get_pkan(self, token):
+    def get_pkan(self, airing_id, token):
         """Return a 'pkan' token needed to request a stream URL."""
         url = 'http://neulion.go.com/espngeo/dgetpkan'
         payload = {
@@ -158,7 +158,7 @@ class ESPNPlayer(object):
             'channel': channel,
             'playbackScenario': 'HTTP_CLOUD_WIRED',
             'playerId': 'neulion',
-            'pkan': self.get_pkan(espntoken),
+            'pkan': self.get_pkan(airing_id, espntoken),
             'pkanType': 'TOKEN',
             'tokenType': 'GATEKEEPER',
             'ttl': '480',
@@ -167,7 +167,7 @@ class ESPNPlayer(object):
             'auth_timestamp': espntoken['timestamp'],
             'auth_token': espntoken['token'],
             'auth_usertrackname': espntoken['userTrackName'],
-            'simulcastAiringId': airing_id if channel!='espn3' else 0
+            'simulcastAiringId': airing_id if chennel!='espn3' else 0
         }
         req = self.make_request(url=url, method='post', payload=payload)
         stream_data = req.content


### PR DESCRIPTION
Here's the espnplayer lib changes as requested for getting an espntoken, pkan, and stream url. I adapted it to your variable name, but it might need tweaked a bit when the remaining pieces are in place.

Note: Some changes with the live channels is the airing_id is now the channel name (espnu,longhorn,sec) and the the simulcast id is 0, which is why there's the if channel==espn3 there. The old code seemed to set airing_id to 0, which will fail to find a stream url.

lots of schema changes as well, mostly just small tweaks to names, but for filtering into what used to be status (upcoming, inplay, archive) is now gameState, and it's
0: 'upcoming',
1: 'inplay',
3: 'archive'

not sure if there's ever a 2.

Hope it helps.